### PR TITLE
textlist alignment fix for lastest ES updates

### DIFF
--- a/layouts/1920x1080.xml
+++ b/layouts/1920x1080.xml
@@ -8,11 +8,11 @@ author:			ruckage
     <view name="basic, detailed,video">
 
 		<textlist name="gamelist">
-			<pos>${listx} 0.2259259259259259</pos>		
-			<size>${listWidth} 0.5481481481481481</size>
+			<pos>0.29 0.195</pos>		
+			<size>0.42 0.63</size>
 			<lineSpacing>1.375</lineSpacing>
 			<selectorHeight>0.0814814814814815</selectorHeight>
-			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
+			<selectorOffsetY>-0.0122</selectorOffsetY>
 		</textlist>
 		
 	</view>


### PR DESCRIPTION
- Seems as if both X & Y co-ordinates need to be defined for "pos", "size", and minor adjustment to "selectOffsetY"
- works in 1080p (haven't tested other resolution layouts)